### PR TITLE
Enable dependabot to keep submodules up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: "gitsubmodule" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gitsubmodule"  # See documentation for possible values
+    directory: "/"  # Location of package manifests
     schedule:
       interval: "weekly"
+
+    allow:
+      - dependency-name: "external/pipeline-Nextflow-config"
+      - dependency-name: "external/pipeline-Nextflow-module"


### PR DESCRIPTION
# Description
This enables [dependabot](https://github.com/dependabot) for this repository, specifically to keep git submodules up-to-date. Once merged, dependabot will automatically open pull requests to update any submodules to the latest versions. Thereafter, it will check weekly to see if new commits have been made to those submodules, opening new PRs as necessary.

See https://github.com/uclahs-cds/group-nextflow-working-group/issues/50 for more context for these changes.

No PRs, including this one and all dependabot PRs, will have the power to make updates without human intervention. The changes will still need to be tested manually before they should be merged.
