### PR TITLE
Release `v6.0.0-rc.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ---
 
 ## [Unreleased]
+
+---
+
+## [6.0.0-rc.3] - 2024-05-13
 ### Added
 + More descriptive error messages on failure to identify output files
 + Add call-sCNA to `requested_pipelines` in `template.config`

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,5 +3,5 @@ manifest {
     name = 'metapipeline-DNA'
     author = ['Yash Patel', 'Chenghao Zhu', 'Helena Winata', 'Alfredo Enrique Gonzalez', 'Nicholas Wang', 'Sorel Fitz-Gibbon', 'Mohammed Faizal Eeman Mootor', 'Nicole Zeltser']
     description = 'Nextflow pipeline to convert BAM to FASTQ, align, call gSNP, call sSNV, call gSV, call sSV and call mtSNV'
-    version = '6.0.0-rc.2'
+    version = '6.0.0-rc.3'
 }


### PR DESCRIPTION

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [X] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the pipeline on at least one A-mini sample.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Releasing v6.0.0-rc.3 since several fixes and changes have been made and this release will likely be the last one before full functionality for call-SRC is included in the releases
