### PR TITLE
Add sanitization to allow special characters such as underscores in IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Changed
 + Update README
++ Add sanitization to sample IDs to account for standardized filenames
 
 ---
 

--- a/module/align_DNA/identify_outputs.nf
+++ b/module/align_DNA/identify_outputs.nf
@@ -1,4 +1,5 @@
 include { identify_file } from '../common'
+include { sanitize_string } from '../../external/pipeline-Nextflow-module/modules/common/generate_standardized_filename/main.nf'
 
 workflow identify_align_dna_outputs {
     take:
@@ -7,7 +8,7 @@ workflow identify_align_dna_outputs {
     main:
     och_align_dna.map{ align_dna_out ->
         params.sample_data[align_dna_out[0]]['align-DNA'].each { aligner_tool, aligner_output ->
-            aligner_output['BAM'] = identify_file("${align_dna_out[1]}/${aligner_tool}*/output/${aligner_tool}*${align_dna_out[0]}.bam")
+            aligner_output['BAM'] = identify_file("${align_dna_out[1]}/${aligner_tool}*/output/${aligner_tool}*${sanitize_string(align_dna_out[0])}.bam")
         };
 
         return 'done'

--- a/module/calculate_targeted_coverage/identify_outputs.nf
+++ b/module/calculate_targeted_coverage/identify_outputs.nf
@@ -1,4 +1,5 @@
 include { identify_file } from '../common'
+include { sanitize_string } from '../../external/pipeline-Nextflow-module/modules/common/generate_standardized_filename/main.nf'
 
 workflow identify_targeted_coverage_outputs {
     take:
@@ -6,7 +7,7 @@ workflow identify_targeted_coverage_outputs {
 
     main:
     och_targeted_coverage.map{ targeted_coverage_out ->
-        params.sample_data[targeted_coverage_out[0]]['calculate-targeted-coverage']['expanded-intervals'] = identify_file("${targeted_coverage_out[1]}/BEDtools-*${targeted_coverage_out[0]}*target-with-enriched-off-target-intervals.bed.gz");
+        params.sample_data[targeted_coverage_out[0]]['calculate-targeted-coverage']['expanded-intervals'] = identify_file("${targeted_coverage_out[1]}/BEDtools-*${sanitize_string(targeted_coverage_out[0])}*target-with-enriched-off-target-intervals.bed.gz");
 
         return 'done'
     }

--- a/module/call_sCNA/identify_outputs.nf
+++ b/module/call_sCNA/identify_outputs.nf
@@ -1,4 +1,5 @@
 include { identify_file } from '../common'
+include { sanitize_string } from '../../external/pipeline-Nextflow-module/modules/common/generate_standardized_filename/main.nf'
 
 workflow identify_call_scna_outputs {
     take:
@@ -6,7 +7,8 @@ workflow identify_call_scna_outputs {
 
     main:
     och_call_scna.map{ call_scna_out ->
-        def sample_id = call_scna_out[0];
+        def raw_sample_id = call_scna_out[0];
+        def sample_id = sanitize_string(raw_sample_id);
         def scna_output_dir = new File(call_scna_out[1].toString());
         def scna_output_pattern = /(.*)-([\d\.]*)$/;
 
@@ -34,7 +36,7 @@ workflow identify_call_scna_outputs {
                 found_files << identify_file("${scna_output_dir}/${output_dir_name}/output/${f}");
             }
 
-            params.sample_data[sample_id]['call-sCNA'][output_info[output_tool][0]] = found_files;
+            params.sample_data[raw_sample_id]['call-sCNA'][output_info[output_tool][0]] = found_files;
         }
 
         return 'done';

--- a/module/call_sSNV/identify_outputs.nf
+++ b/module/call_sSNV/identify_outputs.nf
@@ -1,4 +1,5 @@
 include { identify_file } from '../common'
+include { sanitize_string } from '../../external/pipeline-Nextflow-module/modules/common/generate_standardized_filename/main.nf'
 
 workflow identify_call_ssnv_outputs {
     take:
@@ -6,7 +7,8 @@ workflow identify_call_ssnv_outputs {
 
     main:
     och_call_ssnv.map{ call_ssnv_out ->
-        def sample_id = call_ssnv_out[0];
+        def raw_sample_id = call_ssnv_out[0];
+        def sample_id = sanitize_string(raw_sample_id);
         def ssnv_output_dir = new File(call_ssnv_out[1].toString());
         def ssnv_output_pattern = /(.*)-([\d\.]*)$/;
         if (sample_id == params.patient) { // Output from multi-mode, skip
@@ -32,7 +34,7 @@ workflow identify_call_ssnv_outputs {
         }
 
         outputs_to_check.each { output_tool, output_dir_name ->
-            params.sample_data[sample_id]['call-sSNV'][output_info[output_tool][0]] = identify_file("${ssnv_output_dir}/${output_dir_name}/output/${output_info[output_tool][1]}");
+            params.sample_data[raw_sample_id]['call-sSNV'][output_info[output_tool][0]] = identify_file("${ssnv_output_dir}/${output_dir_name}/output/${output_info[output_tool][1]}");
         }
 
         return 'done';

--- a/module/call_sSNV/run_call_sSNV.nf
+++ b/module/call_sSNV/run_call_sSNV.nf
@@ -3,6 +3,7 @@
 */
 
 include { combine_input_with_params; generate_graceful_error_controller; generate_weblog_args } from '../common.nf'
+include { sanitize_string } from '../../external/pipeline-Nextflow-module/modules/common/generate_standardized_filename/main.nf'
 
 /*
 * Process to call the call-sSNV pipeline
@@ -43,7 +44,7 @@ process run_call_sSNV {
         env EXIT_CODE, emit: exit_code
 
     script:
-    output_directory = "call-sSNV-*/${sample_id}"
+    output_directory = "call-sSNV-*/${(sample_id == params.patient) ? sample_id : sanitize_string(sample_id)}"
     def algorithm_list = (algorithms in List) ? algorithms : [algorithms]
     String params_to_dump = combine_input_with_params(params.call_sSNV.metapipeline_arg_map + ['algorithm': algorithm_list], new File(input_yaml.toRealPath().toString()))
     String setup_commands = generate_graceful_error_controller(task.ext)

--- a/module/recalibrate_BAM/identify_outputs.nf
+++ b/module/recalibrate_BAM/identify_outputs.nf
@@ -1,4 +1,5 @@
 include { identify_file; delete_file } from '../common'
+include { sanitize_string } from '../../external/pipeline-Nextflow-module/modules/common/generate_standardized_filename/main.nf'
 
 workflow identify_recalibrate_bam_outputs {
     take:
@@ -7,23 +8,23 @@ workflow identify_recalibrate_bam_outputs {
     main:
     och_recalibrate_bam.map{ recalibrate_bam_out ->
         recalibrate_bam_out[0].normal.each { normal_sample ->
-            String bam_file = identify_file("${recalibrate_bam_out[1]}/*GATK-*${normal_sample}*.bam");
+            String bam_file = identify_file("${recalibrate_bam_out[1]}/*GATK-*${sanitize_string(normal_sample)}*.bam");
             if (!params.sample_data[normal_sample]['recalibrate-BAM']['BAM']) {
                 params.sample_data[normal_sample]['recalibrate-BAM']['BAM'] = bam_file;
-                params.sample_data[normal_sample]['recalibrate-BAM']['contamination_table'] = identify_file("${recalibrate_bam_out[2]}/GATK-*${normal_sample}_alone.table");
+                params.sample_data[normal_sample]['recalibrate-BAM']['contamination_table'] = identify_file("${recalibrate_bam_out[2]}/GATK-*${sanitize_string(normal_sample)}_alone.table");
             } else {
                 // Normal file already found so delete any other normals - only triggered when running multiple samples in paired mode
 
                 // Replace the work_dir prefix in the output path with the output_dir prefix for final output
                 String separator = "/recalibrate-BAM-";
                 String dir_stripped = recalibrate_bam_out[1].toString().replaceFirst("${params.work_dir}.*${separator}", "");
-                delete_file(bam_file, "${params.output_dir}/output${separator}${dir_stripped}/*GATK-*${normal_sample}*.bam");
+                delete_file(bam_file, "${params.output_dir}/output${separator}${dir_stripped}/*GATK-*${sanitize_string(normal_sample)}*.bam");
             };
         };
         recalibrate_bam_out[0].tumor.each { tumor_sample ->
             String table_suffix = (params.sample_mode == 'single') ? 'alone' : 'with-matched-normal'
-            params.sample_data[tumor_sample]['recalibrate-BAM']['BAM'] = identify_file("${recalibrate_bam_out[1]}/*GATK-*${tumor_sample}*.bam");
-            params.sample_data[tumor_sample]['recalibrate-BAM']['contamination_table'] = identify_file("${recalibrate_bam_out[2]}/GATK-*${tumor_sample}_${table_suffix}.table");
+            params.sample_data[tumor_sample]['recalibrate-BAM']['BAM'] = identify_file("${recalibrate_bam_out[1]}/*GATK-*${sanitize_string(tumor_sample)}*.bam");
+            params.sample_data[tumor_sample]['recalibrate-BAM']['contamination_table'] = identify_file("${recalibrate_bam_out[2]}/GATK-*${sanitize_string(tumor_sample)}_${table_suffix}.table");
         };
 
         return 'done'


### PR DESCRIPTION
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the pipeline on at least one A-mini sample.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #224 

Adding appropriate sanitization to handle special characters that may be present in sample IDs (ex. underscores)

## Testing Results
Tested with `test-metapipeline-DNA-fastq-input`: `/hot/software/pipeline/metapipeline-DNA/Nextflow/development/unreleased/yashpatel-allow-underscore/test-metapipeline-DNA-fastq-input`