### PR TITLE
Update cluster reference paths

### DIFF
--- a/config/template.config
+++ b/config/template.config
@@ -59,24 +59,24 @@ params {
         align_DNA {
             enable_spark = true
             mark_duplicates = true
-            reference_fasta_bwa = '/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa'
+            reference_fasta_bwa = '/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa'
             aligner = ['BWA-MEM2']
         }
 
         recalibrate_BAM {
             aligner = "BWA-MEM2-2.2.1"
-            reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
-            bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
-            bundle_known_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz"
-            bundle_v0_dbsnp138_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
-            bundle_contest_hapmap_3p3_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz"
+            reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+            bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
+            bundle_known_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz"
+            bundle_v0_dbsnp138_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
+            bundle_contest_hapmap_3p3_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz"
             parallelize_by_chromosome = true
         }
 
         calculate_targeted_coverage {
-            reference_dict = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict'
-            reference_dbSNP = '/hot/ref/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz'
-            genome_sizes = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai'
+            reference_dict = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict'
+            reference_dbSNP = '/hot/resource/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz'
+            genome_sizes = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai'
             target_bed = 'path/to/target/bedfile' //required
             bait_bed = '' //optional, path/to/bait/bedfile
             collect_metrics = true // whether or not to calculate coverage metrics
@@ -87,52 +87,52 @@ params {
 
         generate_SQC_BAM {
             algorithms = ['stats', 'collectwgsmetrics']
-            reference = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+            reference = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
         }
 
         call_gSNP {
-            reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
-            bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
-            bundle_v0_dbsnp138_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
-            bundle_hapmap_3p3_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz"
-            bundle_omni_1000g_2p5_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz"
-            bundle_phase1_1000g_snps_high_conf_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
+            reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+            bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
+            bundle_v0_dbsnp138_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
+            bundle_hapmap_3p3_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz"
+            bundle_omni_1000g_2p5_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz"
+            bundle_phase1_1000g_snps_high_conf_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
         }
 
         call_sSNV {
             algorithm = ['somaticsniper', 'strelka2', 'mutect2', 'muse']
-            reference = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+            reference = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
             exome = false
-            intersect_regions = '/hot/ref/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz'
-            germline_resource_gnomad_vcf = '/hot/ref/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz'
-            dbSNP = '/hot/ref/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz'
+            intersect_regions = '/hot/resource/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz'
+            germline_resource_gnomad_vcf = '/hot/resource/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz'
+            dbSNP = '/hot/resource/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz'
             ncbi_build = 'GRCh38'
         }
 
         call_mtSNV {
-            mt_ref_genome_dir = '/hot/ref/mitochondria_ref/genome_fasta/'
-            gmapdb = '/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08/'
+            mt_ref_genome_dir = '/hot/resource/mitochondria_ref/genome_fasta/'
+            gmapdb = '/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08/'
         }
 
         call_gSV {
-            reference_fasta = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
-            exclusion_file = '/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv'
-            mappability_map = '/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz'
+            reference_fasta = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+            exclusion_file = '/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv'
+            mappability_map = '/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz'
         }
 
         call_sSV {
             algorithm = ['delly', 'manta']
-            reference_fasta = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
-            exclusion_file = '/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv'
+            reference_fasta = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+            exclusion_file = '/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv'
         }
 
         call_sCNA {
             algorithm = ['battenberg', 'cnv_facets']
             sample_sex = "male"
             position_scale = "genome-position"
-            dbSNP_file = "/hot/ref/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz"
-            battenberg_reference = "/hot/ref/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/"
-            reference_dict = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict"
+            dbSNP_file = "/hot/resource/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz"
+            battenberg_reference = "/hot/resource/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/"
+            reference_dict = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict"
         }
 
         call_SRC {

--- a/module/call_gSNP/default.config
+++ b/module/call_gSNP/default.config
@@ -33,15 +33,15 @@ params {
 
     // Reference - Used here hg38 decoy version
     // GATK requires the reference fasta to be accompanied by a .fai index and .dict dictionary associated with the fasta for fast random access
-    // These can be found in the same folder as the reference here: /hot/ref/reference/GRCh38-BI-20160721
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    // These can be found in the same folder as the reference here: /hot/resource/reference-genome/GRCh38-BI-20160721
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
     // GATK bundle - Used here hg38 decoy version
-    bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
-    bundle_v0_dbsnp138_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
-    bundle_hapmap_3p3_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz"
-    bundle_omni_1000g_2p5_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz"
-    bundle_phase1_1000g_snps_high_conf_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
+    bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
+    bundle_v0_dbsnp138_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
+    bundle_hapmap_3p3_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz"
+    bundle_omni_1000g_2p5_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz"
+    bundle_phase1_1000g_snps_high_conf_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
 
     // Base resource allocation updater
     // See README for adding parameters to update the base resource allocations

--- a/module/call_gSV/default.config
+++ b/module/call_gSV/default.config
@@ -27,10 +27,10 @@ params {
     // input_csv = "path/to/input/csv/"
     output_dir = ""
 
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
-    // exclusion_file = "/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv"
-    // mappability_map = "/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz"
+    // exclusion_file = "/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv"
+    // mappability_map = "/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz"
 
     map_qual = 20 // min. paired-end (PE) mapping quality for Delly
     }

--- a/module/call_sSNV/default.config
+++ b/module/call_sSNV/default.config
@@ -12,8 +12,8 @@ includeConfig "${projectDir}/config/methods.config"
 
 params {
     algorithm = [] // 'somaticsniper', 'strelka2', 'mutect2', 'muse'
-    reference = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
-    intersect_regions = '/hot/ref/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz'
+    reference = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+    intersect_regions = '/hot/resource/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz'
     output_dir = ''
     work_dir = ''
     dataset_id = ''
@@ -32,10 +32,10 @@ params {
     filter_mutect_calls_extra_args = ''
     gatk_command_mem_diff = 500.MB
     scatter_count = 50
-    // germline_resource_gnomad_vcf = '/hot/ref/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz'
+    // germline_resource_gnomad_vcf = '/hot/resource/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz'
 
     // MuSE options
-    // dbSNP = '/hot/ref/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz'
+    // dbSNP = '/hot/resource/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz'
 
     // Intersect options
     ncbi_build = 'GRCh38'

--- a/module/call_sSV/default.config
+++ b/module/call_sSV/default.config
@@ -11,9 +11,9 @@ params {
 
     blcds_registered_dataset = false
 
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
-    // exclusion_file = "/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv"
+    // exclusion_file = "/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv"
 
     output_dir = ''
 

--- a/module/convert_BAM2FASTQ/default.config
+++ b/module/convert_BAM2FASTQ/default.config
@@ -12,7 +12,7 @@ params {
     // input_csv = "/absolute/path/to/input.csv"
     // output_dir = "/absolute/path/to/output_directory"
     // temp_dir = "/scratch/"
-    reference_genome = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    reference_genome = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
     // processing options
     filter_qc_failed_reads = false

--- a/module/generate_SQC_BAM/default.config
+++ b/module/generate_SQC_BAM/default.config
@@ -9,7 +9,7 @@ includeConfig "${projectDir}/nextflow.config"
 // Inputs/parameters of the pipeline
 params {
     algorithms = ['stats', 'collectwgsmetrics'] // 'stats', 'collectwgsmetrics', 'bamqc'
-    reference = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+    reference = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
     blcds_registered_dataset = false // if you want the output to be registered
     save_intermediate_files = true
 

--- a/module/recalibrate_BAM/default.config
+++ b/module/recalibrate_BAM/default.config
@@ -41,8 +41,8 @@ params {
 
     // Reference - Used here hg38 decoy version
     // GATK requires the reference fasta to be accompanied by a .fai index and .dict dictionary associated with the fasta for fast random access
-    // These can be found in the same folder as the reference here: /hot/ref/reference/GRCh38-BI-20160721
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    // These can be found in the same folder as the reference here: /hot/resource/reference-genome/GRCh38-BI-20160721
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
     // Whether to parallelize the pipeline by chromosome or by splitting into equal-sized intervals
     // The scatter_count and extra args below only go into effect if parallelize_by_chromosome is disabled
@@ -51,10 +51,10 @@ params {
     split_intervals_extra_args = ''
 
     // GATK bundle - Used here hg38 decoy version
-    bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
-    bundle_known_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz"
-    bundle_v0_dbsnp138_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
-    bundle_contest_hapmap_3p3_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz"
+    bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
+    bundle_known_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz"
+    bundle_v0_dbsnp138_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
+    bundle_contest_hapmap_3p3_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz"
 
     // Base resource allocation updater
     // See README for adding parameters to update the base resource allocations

--- a/test/test-align-DNA/test.config
+++ b/test/test-align-DNA/test.config
@@ -10,7 +10,7 @@ params {
         enable_spark = true
         mark_duplicates = true
         subworkflow_cpus = 8
-        reference_fasta_bwa = '/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa'
+        reference_fasta_bwa = '/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa'
         aligner = ['BWA-MEM2']
     }
 

--- a/test/test-calculate-targeted-coverage/test.config
+++ b/test/test-calculate-targeted-coverage/test.config
@@ -12,9 +12,9 @@ params {
 
     calculate_targeted_coverage {
         is_pipeline_enabled = true
-        reference_dict = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict'
-        reference_dbSNP = '/hot/ref/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz'
-        genome_sizes = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai'
+        reference_dict = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict'
+        reference_dbSNP = '/hot/resource/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz'
+        genome_sizes = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai'
         target_bed = '/hot/software/pipeline/metapipeline-DNA/Nextflow/development/input/data/targeted-coverage/small.bed' //required
         bait_bed = '' //optional, path/to/bait/bedfile
         collect_metrics = true // whether or not to calculate coverage metrics

--- a/test/test-call-gSNP/test.config
+++ b/test/test-call-gSNP/test.config
@@ -11,12 +11,12 @@ params {
         is_pipeline_enabled = true
         subworkflow_cpus = SysHelper.getAvailCpus()
         max_number_of_parallel_jobs = 2
-        reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
-        bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
-        bundle_v0_dbsnp138_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
-        bundle_hapmap_3p3_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz"
-        bundle_omni_1000g_2p5_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz"
-        bundle_phase1_1000g_snps_high_conf_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
+        reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+        bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
+        bundle_v0_dbsnp138_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
+        bundle_hapmap_3p3_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz"
+        bundle_omni_1000g_2p5_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz"
+        bundle_phase1_1000g_snps_high_conf_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
     }
 
     arg_map = [:]

--- a/test/test-call-gSV/test.config
+++ b/test/test-call-gSV/test.config
@@ -8,9 +8,9 @@ params {
     call_gSV {
         is_pipeline_enabled = true
         subworkflow_cpus = 8
-        reference_fasta = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
-        exclusion_file = '/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv'
-        mappability_map = '/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz'
+        reference_fasta = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+        exclusion_file = '/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv'
+        mappability_map = '/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz'
         run_delly = false
     }
 

--- a/test/test-call-mtSNV/test.config
+++ b/test/test-call-mtSNV/test.config
@@ -8,8 +8,8 @@ params {
     call_mtSNV {
         is_pipeline_enabled = true
         subworkflow_cpus = 8
-        mt_ref_genome_dir = '/hot/ref/mitochondria_ref/genome_fasta/'
-        gmapdb = '/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08/'
+        mt_ref_genome_dir = '/hot/resource/mitochondria_ref/genome_fasta/'
+        gmapdb = '/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08/'
     }
 
     arg_map = [:]

--- a/test/test-call-sCNA/test-Battenberg.config
+++ b/test/test-call-sCNA/test-Battenberg.config
@@ -11,9 +11,9 @@ params {
         algorithm = ['battenberg']
         sample_sex = "female"
         position_scale = "genome-position"
-        dbSNP_file = "/hot/ref/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz"
-        battenberg_reference = "/hot/ref/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/"
-        reference_dict = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict"
+        dbSNP_file = "/hot/resource/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz"
+        battenberg_reference = "/hot/resource/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/"
+        reference_dict = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict"
     }
 
     call_SRC {

--- a/test/test-call-sCNA/test-cnv_facets.config
+++ b/test/test-call-sCNA/test-cnv_facets.config
@@ -11,9 +11,9 @@ params {
         algorithm = ['cnv_facets']
         sample_sex = "male"
         position_scale = "genome-position"
-        dbSNP_file = "/hot/ref/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz"
-        battenberg_reference = "/hot/ref/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/"
-        reference_dict = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict"
+        dbSNP_file = "/hot/resource/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz"
+        battenberg_reference = "/hot/resource/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/"
+        reference_dict = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict"
     }
 
     call_SRC {

--- a/test/test-call-sSNV/test.config
+++ b/test/test-call-sSNV/test.config
@@ -10,11 +10,11 @@ params {
         is_pipeline_enabled = true
         subworkflow_cpus = 8
         algorithm = ['somaticsniper', 'strelka2', 'mutect2', 'muse']
-        reference = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+        reference = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
         exome = false
         intersect_regions = "${launchDir}/test/test-call-sSNV/Homo_sapiens_assembly38_no-decoy_downsampled.bed.gz"
-        germline_resource_gnomad_vcf = '/hot/ref/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz'
-        dbSNP = '/hot/ref/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz'
+        germline_resource_gnomad_vcf = '/hot/resource/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz'
+        dbSNP = '/hot/resource/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz'
         ncbi_build = 'GRCh38'
     }
 

--- a/test/test-call-sSV/test.config
+++ b/test/test-call-sSV/test.config
@@ -8,9 +8,9 @@ params {
     call_sSV {
         is_pipeline_enabled = true
         subworkflow_cpus = 8
-        reference_fasta = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+        reference_fasta = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
         algorithm = ['delly', 'manta']
-        exclusion_file = '/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv'
+        exclusion_file = '/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv'
     }
 
     arg_map = [:]

--- a/test/test-generate-SQC-BAM/test.config
+++ b/test/test-generate-SQC-BAM/test.config
@@ -11,7 +11,7 @@ params {
         is_pipeline_enabled = true
         subworkflow_cpus = SysHelper.getAvailCpus()
         algorithms = ['stats', 'collectwgsmetrics']
-        reference = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+        reference = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
     }
 
     arg_map = [:]

--- a/test/test-metapipeline-DNA-batch/test.config
+++ b/test/test-metapipeline-DNA-batch/test.config
@@ -35,61 +35,61 @@ params {
         align_DNA {
             enable_spark = true
             mark_duplicates = true
-            reference_fasta_bwa = '/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa'
+            reference_fasta_bwa = '/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa'
             aligner = ['BWA-MEM2']
         }
 
         recalibrate_BAM {
             aligner = "BWA-MEM2-2.2.1"
-            reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
-            bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
-            bundle_known_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz"
-            bundle_v0_dbsnp138_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
-            bundle_contest_hapmap_3p3_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz"
+            reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+            bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
+            bundle_known_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz"
+            bundle_v0_dbsnp138_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
+            bundle_contest_hapmap_3p3_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz"
             parallelize_by_chromosome = true
         }
 
         call_gSNP {
-            reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
-            bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
-            bundle_v0_dbsnp138_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
-            bundle_hapmap_3p3_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz"
-            bundle_omni_1000g_2p5_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz"
-            bundle_phase1_1000g_snps_high_conf_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
+            reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+            bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
+            bundle_v0_dbsnp138_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
+            bundle_hapmap_3p3_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz"
+            bundle_omni_1000g_2p5_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz"
+            bundle_phase1_1000g_snps_high_conf_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
         }
 
         call_sSNV {
             algorithm = ['somaticsniper', 'strelka2', 'mutect2', 'muse']
-            reference = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+            reference = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
             exome = false
-            intersect_regions = '/hot/ref/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz'
-            germline_resource_gnomad_vcf = '/hot/ref/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz'
-            dbSNP = '/hot/ref/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz'
+            intersect_regions = '/hot/resource/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz'
+            germline_resource_gnomad_vcf = '/hot/resource/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz'
+            dbSNP = '/hot/resource/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz'
             ncbi_build = 'GRCh38'
         }
 
         call_mtSNV {
-            mt_ref_genome_dir = '/hot/ref/mitochondria_ref/genome_fasta/'
-            gmapdb = '/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08/'
+            mt_ref_genome_dir = '/hot/resource/mitochondria_ref/genome_fasta/'
+            gmapdb = '/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08/'
         }
 
         call_gSV {
-            reference_fasta = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
-            exclusion_file = '/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv'
-            mappability_map = '/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz'
+            reference_fasta = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+            exclusion_file = '/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv'
+            mappability_map = '/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz'
             run_delly = false
         }
 
         call_sSV {
             algorithm = ['delly', 'manta']
-            reference_fasta = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
-            exclusion_file = '/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv'
+            reference_fasta = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+            exclusion_file = '/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv'
         }
 
         calculate_targeted_coverage {
-            reference_dict = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict'
-            reference_dbSNP = '/hot/ref/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz'
-            genome_sizes = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai'
+            reference_dict = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict'
+            reference_dbSNP = '/hot/resource/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz'
+            genome_sizes = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai'
             target_bed = '/hot/software/pipeline/metapipeline-DNA/Nextflow/development/input/data/targeted-coverage/small.bed' //required
             bait_bed = '' //optional, path/to/bait/bedfile
             collect_metrics = true // whether or not to calculate coverage metrics
@@ -100,16 +100,16 @@ params {
 
         generate_SQC_BAM {
             algorithms = ['stats', 'collectwgsmetrics']
-            reference = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+            reference = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
         }
 
         call_sCNA {
             algorithm = ['cnv_facets']
             sample_sex = "male"
             position_scale = "genome-position"
-            dbSNP_file = "/hot/ref/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz"
-            battenberg_reference = "/hot/ref/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/"
-            reference_dict = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict"
+            dbSNP_file = "/hot/resource/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz"
+            battenberg_reference = "/hot/resource/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/"
+            reference_dict = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict"
         }
 
         call_SRC {

--- a/test/test-metapipeline-DNA-fastq-input/test.config
+++ b/test/test-metapipeline-DNA-fastq-input/test.config
@@ -30,24 +30,24 @@ params {
         align_DNA {
             enable_spark = true
             mark_duplicates = true
-            reference_fasta_bwa = '/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa'
+            reference_fasta_bwa = '/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa'
             aligner = ['BWA-MEM2']
         }
 
         recalibrate_BAM {
             aligner = "BWA-MEM2-2.2.1"
-            reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
-            bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
-            bundle_known_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz"
-            bundle_v0_dbsnp138_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
-            bundle_contest_hapmap_3p3_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz"
+            reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+            bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
+            bundle_known_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz"
+            bundle_v0_dbsnp138_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
+            bundle_contest_hapmap_3p3_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz"
             parallelize_by_chromosome = true
         }
 
         calculate_targeted_coverage {
-            reference_dict = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict'
-            reference_dbSNP = '/hot/ref/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz'
-            genome_sizes = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai'
+            reference_dict = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict'
+            reference_dbSNP = '/hot/resource/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz'
+            genome_sizes = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai'
             target_bed = '/hot/software/pipeline/metapipeline-DNA/Nextflow/development/input/data/targeted-coverage/small.bed' //required
             bait_bed = '' //optional, path/to/bait/bedfile
             collect_metrics = true // whether or not to calculate coverage metrics
@@ -59,52 +59,52 @@ params {
 
         generate_SQC_BAM {
             algorithms = ['stats', 'collectwgsmetrics']
-            reference = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+            reference = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
         }
 
         call_gSNP {
-            reference_fasta = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
-            bundle_mills_and_1000g_gold_standard_indels_vcf_gz = '/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz'
-            bundle_v0_dbsnp138_vcf_gz = '/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz'
-            bundle_hapmap_3p3_vcf_gz = '/hot/ref/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz'
-            bundle_omni_1000g_2p5_vcf_gz = '/hot/ref/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz'
-            bundle_phase1_1000g_snps_high_conf_vcf_gz = '/hot/ref/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz'
+            reference_fasta = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+            bundle_mills_and_1000g_gold_standard_indels_vcf_gz = '/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz'
+            bundle_v0_dbsnp138_vcf_gz = '/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz'
+            bundle_hapmap_3p3_vcf_gz = '/hot/resource/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz'
+            bundle_omni_1000g_2p5_vcf_gz = '/hot/resource/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz'
+            bundle_phase1_1000g_snps_high_conf_vcf_gz = '/hot/resource/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz'
         }
 
         call_sSNV {
             algorithm = ['somaticsniper', 'strelka2', 'mutect2', 'muse']
-            reference = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+            reference = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
             exome = false
-            intersect_regions = '/hot/ref/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz'
-            germline_resource_gnomad_vcf = '/hot/ref/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz'
-            dbSNP = '/hot/ref/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz'
+            intersect_regions = '/hot/resource/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz'
+            germline_resource_gnomad_vcf = '/hot/resource/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz'
+            dbSNP = '/hot/resource/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz'
             ncbi_build = 'GRCh38'
         }
 
         call_mtSNV {
-            mt_ref_genome_dir = '/hot/ref/mitochondria_ref/genome_fasta/'
-            gmapdb = '/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08/'
+            mt_ref_genome_dir = '/hot/resource/mitochondria_ref/genome_fasta/'
+            gmapdb = '/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08/'
         }
 
         call_gSV {
-            reference_fasta = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
-            exclusion_file = '/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv'
-            mappability_map = '/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz'
+            reference_fasta = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+            exclusion_file = '/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv'
+            mappability_map = '/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz'
             run_delly = false
         }
         call_sSV {
             algorithm = ['delly', 'manta']
-            reference_fasta = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
-            exclusion_file = '/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv'
+            reference_fasta = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+            exclusion_file = '/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv'
         }
         call_sCNA {
             subworkflow_cpus = 8
             algorithm = ['cnv_facets']
             sample_sex = "male"
             position_scale = "genome-position"
-            dbSNP_file = "/hot/ref/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz"
-            battenberg_reference = "/hot/ref/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/"
-            reference_dict = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict"
+            dbSNP_file = "/hot/resource/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz"
+            battenberg_reference = "/hot/resource/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/"
+            reference_dict = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict"
         }
     }
 }

--- a/test/test-metapipeline-DNA/pipeline_specific_params.json
+++ b/test/test-metapipeline-DNA/pipeline_specific_params.json
@@ -14,7 +14,7 @@
     "align_DNA": {
         "enable_spark": true,
         "mark_duplicates": true,
-        "reference_fasta_bwa": "/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa",
+        "reference_fasta_bwa": "/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa",
         "aligner": [
             "BWA-MEM2"
         ],
@@ -23,7 +23,7 @@
         "metapipeline_arg_map": {
             "enable_spark": true,
             "mark_duplicates": true,
-            "reference_fasta_bwa": "/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa",
+            "reference_fasta_bwa": "/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa",
             "aligner": [
                 "BWA-MEM2"
             ],
@@ -33,22 +33,22 @@
     },
     "recalibrate_BAM": {
         "aligner": "BWA-MEM2-2.2.1",
-        "reference_fasta": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
-        "bundle_mills_and_1000g_gold_standard_indels_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
-        "bundle_known_indels_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz",
-        "bundle_v0_dbsnp138_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz",
-        "bundle_contest_hapmap_3p3_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz",
+        "reference_fasta": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+        "bundle_mills_and_1000g_gold_standard_indels_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+        "bundle_known_indels_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz",
+        "bundle_v0_dbsnp138_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz",
+        "bundle_contest_hapmap_3p3_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz",
         "gatk_ir_compression": 5,
         "parallelize_by_chromosome": true,
         "is_pipeline_enabled": true,
         "subworkflow_cpus": 32,
         "metapipeline_arg_map": {
             "aligner": "BWA-MEM2-2.2.1",
-            "reference_fasta": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
-            "bundle_mills_and_1000g_gold_standard_indels_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
-            "bundle_known_indels_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz",
-            "bundle_v0_dbsnp138_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz",
-            "bundle_contest_hapmap_3p3_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz",
+            "reference_fasta": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+            "bundle_mills_and_1000g_gold_standard_indels_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+            "bundle_known_indels_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz",
+            "bundle_v0_dbsnp138_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz",
+            "bundle_contest_hapmap_3p3_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz",
             "gatk_ir_compression": 5,
             "parallelize_by_chromosome": true,
             "is_pipeline_enabled": true,
@@ -56,9 +56,9 @@
         }
     },
     "calculate_targeted_coverage": {
-        "reference_dict": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict",
-        "reference_dbSNP": "/hot/ref/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz",
-        "genome_sizes": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai",
+        "reference_dict": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict",
+        "reference_dbSNP": "/hot/resource/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz",
+        "genome_sizes": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai",
         "target_bed": "/hot/software/pipeline/metapipeline-DNA/Nextflow/development/input/data/targeted-coverage/small.bed",
         "bait_bed": "",
         "collect_metrics": true,
@@ -68,9 +68,9 @@
         "is_pipeline_enabled": true,
         "subworkflow_cpus": 8,
         "metapipeline_arg_map": {
-            "reference_dict": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict",
-            "reference_dbSNP": "/hot/ref/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz",
-            "genome_sizes": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai",
+            "reference_dict": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict",
+            "reference_dbSNP": "/hot/resource/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz",
+            "genome_sizes": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai",
             "target_bed": "/hot/software/pipeline/metapipeline-DNA/Nextflow/development/input/data/targeted-coverage/small.bed",
             "bait_bed": "",
             "collect_metrics": true,
@@ -86,7 +86,7 @@
             "stats",
             "collectwgsmetrics"
         ],
-        "reference": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+        "reference": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
         "is_pipeline_enabled": true,
         "subworkflow_cpus": 8,
         "metapipeline_arg_map": {
@@ -94,27 +94,27 @@
                 "stats",
                 "collectwgsmetrics"
             ],
-            "reference": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+            "reference": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
             "is_pipeline_enabled": true,
             "subworkflow_cpus": 8
         }
     },
     "call_gSNP": {
-        "reference_fasta": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
-        "bundle_mills_and_1000g_gold_standard_indels_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
-        "bundle_v0_dbsnp138_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz",
-        "bundle_hapmap_3p3_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz",
-        "bundle_omni_1000g_2p5_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz",
-        "bundle_phase1_1000g_snps_high_conf_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz",
+        "reference_fasta": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+        "bundle_mills_and_1000g_gold_standard_indels_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+        "bundle_v0_dbsnp138_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz",
+        "bundle_hapmap_3p3_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz",
+        "bundle_omni_1000g_2p5_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz",
+        "bundle_phase1_1000g_snps_high_conf_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz",
         "is_pipeline_enabled": true,
         "subworkflow_cpus": 32,
         "metapipeline_arg_map": {
-            "reference_fasta": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
-            "bundle_mills_and_1000g_gold_standard_indels_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
-            "bundle_v0_dbsnp138_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz",
-            "bundle_hapmap_3p3_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz",
-            "bundle_omni_1000g_2p5_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz",
-            "bundle_phase1_1000g_snps_high_conf_vcf_gz": "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz",
+            "reference_fasta": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+            "bundle_mills_and_1000g_gold_standard_indels_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+            "bundle_v0_dbsnp138_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz",
+            "bundle_hapmap_3p3_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz",
+            "bundle_omni_1000g_2p5_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz",
+            "bundle_phase1_1000g_snps_high_conf_vcf_gz": "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz",
             "is_pipeline_enabled": true,
             "subworkflow_cpus": 32
         }
@@ -126,48 +126,48 @@
             "mutect2",
             "muse"
         ],
-        "reference": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+        "reference": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
         "exome": false,
-        "intersect_regions": "/hot/ref/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz",
-        "germline_resource_gnomad_vcf": "/hot/ref/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz",
-        "dbSNP": "/hot/ref/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz",
+        "intersect_regions": "/hot/resource/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz",
+        "germline_resource_gnomad_vcf": "/hot/resource/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz",
+        "dbSNP": "/hot/resource/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz",
         "ncbi_build": "GRCh38",
         "is_pipeline_enabled": true,
         "subworkflow_cpus": 8,
         "metapipeline_arg_map": {
-            "reference": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+            "reference": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
             "exome": false,
-            "intersect_regions": "/hot/ref/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz",
-            "germline_resource_gnomad_vcf": "/hot/ref/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz",
-            "dbSNP": "/hot/ref/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz",
+            "intersect_regions": "/hot/resource/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz",
+            "germline_resource_gnomad_vcf": "/hot/resource/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz",
+            "dbSNP": "/hot/resource/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz",
             "ncbi_build": "GRCh38",
             "is_pipeline_enabled": true,
             "subworkflow_cpus": 8
         }
     },
     "call_mtSNV": {
-        "mt_ref_genome_dir": "/hot/ref/mitochondria_ref/genome_fasta/",
-        "gmapdb": "/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08/",
+        "mt_ref_genome_dir": "/hot/resource/mitochondria_ref/genome_fasta/",
+        "gmapdb": "/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08/",
         "is_pipeline_enabled": true,
         "subworkflow_cpus": 8,
         "metapipeline_arg_map": {
-            "mt_ref_genome_dir": "/hot/ref/mitochondria_ref/genome_fasta/",
-            "gmapdb": "/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08/",
+            "mt_ref_genome_dir": "/hot/resource/mitochondria_ref/genome_fasta/",
+            "gmapdb": "/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08/",
             "is_pipeline_enabled": true,
             "subworkflow_cpus": 8
         }
     },
     "call_gSV": {
-        "reference_fasta": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
-        "exclusion_file": "/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv",
-        "mappability_map": "/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz",
+        "reference_fasta": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+        "exclusion_file": "/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv",
+        "mappability_map": "/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz",
         "run_delly": false,
         "is_pipeline_enabled": true,
         "subworkflow_cpus": 8,
         "metapipeline_arg_map": {
-            "reference_fasta": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
-            "exclusion_file": "/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv",
-            "mappability_map": "/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz",
+            "reference_fasta": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+            "exclusion_file": "/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv",
+            "mappability_map": "/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz",
             "run_delly": false,
             "is_pipeline_enabled": true,
             "subworkflow_cpus": 8
@@ -178,8 +178,8 @@
             "delly",
             "manta"
         ],
-        "reference_fasta": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
-        "exclusion_file": "/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv",
+        "reference_fasta": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+        "exclusion_file": "/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv",
         "is_pipeline_enabled": true,
         "subworkflow_cpus": 8,
         "metapipeline_arg_map": {
@@ -187,8 +187,8 @@
                 "delly",
                 "manta"
             ],
-            "reference_fasta": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
-            "exclusion_file": "/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv",
+            "reference_fasta": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+            "exclusion_file": "/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv",
             "is_pipeline_enabled": true,
             "subworkflow_cpus": 8
         }
@@ -199,9 +199,9 @@
         ],
         "sample_sex": "male",
         "position_scale": "genome-position",
-        "dbSNP_file": "/hot/ref/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz",
-        "battenberg_reference": "/hot/ref/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/",
-        "reference_dict": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict",
+        "dbSNP_file": "/hot/resource/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz",
+        "battenberg_reference": "/hot/resource/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/",
+        "reference_dict": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict",
         "is_pipeline_enabled": true,
         "subworkflow_cpus": 8,
         "metapipeline_arg_map": {
@@ -210,9 +210,9 @@
             ],
             "sample_sex": "male",
             "position_scale": "genome-position",
-            "dbSNP_file": "/hot/ref/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz",
-            "battenberg_reference": "/hot/ref/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/",
-            "reference_dict": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict",
+            "dbSNP_file": "/hot/resource/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz",
+            "battenberg_reference": "/hot/resource/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/",
+            "reference_dict": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict",
             "is_pipeline_enabled": true,
             "subworkflow_cpus": 8
         }

--- a/test/test-recalibrate-BAM/test.config
+++ b/test/test-recalibrate-BAM/test.config
@@ -14,11 +14,11 @@ params {
     recalibrate_BAM {
         is_pipeline_enabled = true
         aligner = "BWA-MEM2-2.2.1"
-        reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
-        bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
-        bundle_known_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz"
-        bundle_v0_dbsnp138_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
-        bundle_contest_hapmap_3p3_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz"
+        reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+        bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
+        bundle_known_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz"
+        bundle_v0_dbsnp138_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
+        bundle_contest_hapmap_3p3_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz"
         parallelize_by_chromosome = true
         subworkflow_cpus = SysHelper.getAvailCpus()
         max_number_of_parallel_jobs = 2


### PR DESCRIPTION
This PR updates reference paths that were renamed during the most recent cluster downtime.

I was specifically looking for single lines containing one (or more) of the following keys, so I missed any paths split across multiple lines.

| Search String                                                  |
|----------------------------------------------------------------|
| `/hot/ref/`                                                    |
| `/hot/ref/cohort/TCGA/CCG-AIM/`                                |
| `/hot/ref/cohort/TCGA/PanCanAtlas/`                            |
| `/hot/ref/database/1000Genomes/`                               |
| `/hot/ref/database/GDC-34.0 `                                  |
| `/hot/ref/database/GDC-34.0/`                                  |
| `/hot/ref/database/PCAWG/`                                     |
| `/hot/ref/database/ProstateTumor/Boutros-Yamaguchi-PRAD-CPCG/` |
| `/hot/ref/reference/`                                          |
| `/hot/resource/SMC-HET/`                                       |

A table of updated filepaths and whether or not they resolve to a file is included below. Where the original paths still exist due to symlinks I verified that they resolve to the same file as the updated path.

| Original                                                                                                           |                    | Updated                                                                                                                 |                    |
|--------------------------------------------------------------------------------------------------------------------|--------------------|-------------------------------------------------------------------------------------------------------------------------|--------------------|
| `/hot/ref/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa`                               | :white_check_mark: | `/hot/resource/tool-specific-input/BWA-MEM2-2.2.1/GRCh38-BI-20160721/alt-aware/genome.fa`                               | :white_check_mark: |
| `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta`                                              | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta`                                       | :white_check_mark: |
| `/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz`                        | :white_check_mark: | `/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz`                        | :white_check_mark: |
| `/hot/ref/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz`                             | :white_check_mark: | `/hot/resource/tool-specific-input/GATK/GRCh38/Homo_sapiens_assembly38.known_indels.vcf.gz`                             | :white_check_mark: |
| `/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz`         | :white_check_mark: | `/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz`         | :white_check_mark: |
| `/hot/ref/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz`              | :white_check_mark: | `/hot/resource/tool-specific-input/GATK/GRCh38/Biallelic/hapmap_3.3.hg38.BIALLELIC.PASS.2021-09-01.vcf.gz`              | :white_check_mark: |
| `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict`                                               | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict`                                        | :white_check_mark: |
| `/hot/ref/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz`                                         | :white_check_mark: | `/hot/resource/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz`                                         | :white_check_mark: |
| `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai`                                          | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai`                                   | :white_check_mark: |
| `/hot/ref/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz`                                                  | :white_check_mark: | `/hot/resource/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz`                                                  | :white_check_mark: |
| `/hot/ref/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz`                                               | :white_check_mark: | `/hot/resource/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz`                                               | :white_check_mark: |
| `/hot/ref/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz`                           | :white_check_mark: | `/hot/resource/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz`                           | :white_check_mark: |
| `/hot/ref/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz` | :white_check_mark: | `/hot/resource/tool-specific-input/pipeline-call-sSNV-6.0.0/GRCh38-BI-20160721/Homo_sapiens_assembly38_no-decoy.bed.gz` | :white_check_mark: |
| `/hot/ref/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz`                                              | :white_check_mark: | `/hot/resource/tool-specific-input/GATK/GRCh38/af-only-gnomad.hg38.vcf.gz`                                              | :white_check_mark: |
| `/hot/ref/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz`                                                  | :white_check_mark: | `/hot/resource/database/dbSNP-155/original/GRCh38/GCF_000001405.39.gz`                                                  | :white_check_mark: |
| `/hot/ref/mitochondria_ref/genome_fasta/`                                                                          | :white_check_mark: | `/hot/resource/mitochondria_ref/genome_fasta/`                                                                          | :white_check_mark: |
| `/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08/`                                                              | :white_check_mark: | `/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08/`                                                              | :white_check_mark: |
| `/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv`                                                    | :white_check_mark: | `/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv`                                                    | :white_check_mark: |
| `/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz`     | :white_check_mark: | `/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz`     | :white_check_mark: |
| `/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv`                                                      | :white_check_mark: | `/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv`                                                      | :white_check_mark: |
| `/hot/ref/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz`                                              | :white_check_mark: | `/hot/resource/tool-specific-input/RecSNV/GRCh38/dbsnp_b150_grch38.vcf.gz`                                              | :white_check_mark: |
| `/hot/ref/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/`                          | :white_check_mark: | `/hot/resource/tool-specific-input/Battenberg/download_202204/GRCh38/battenberg_ref_hg38_chr/`                          | :white_check_mark: |
| `/hot/ref/reference/GRCh38-BI-20160721`                                                                            | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721`                                                                     | :white_check_mark: |