### PR TITLE
Fix VCF handling bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix check for VCF input to handle case of FASTQ original input
+
 ## [7.0.0-rc.1] - 2025-03-05
 
 ### Added

--- a/config/default.config
+++ b/config/default.config
@@ -18,27 +18,27 @@ params {
 
     // StableLift model definition
     test_base = "/hot/project/method/AlgorithmEvaluation/BNCH-000142-GRCh37v38/publish"
-    model_37_38 = "${test_base}/model/GRCh37-to-GRCh38/RF-model_GRCh37-to-GRCh38"
-    model_38_37 = "${test_base}/model/GRCh38-to-GRCh37/RF-model_GRCh38-to-GRCh37"
+    model_37_38 = "${test_base}/model/GRCh37-to-GRCh38/RF-train_GRCh37-to-GRCh38"
+    model_38_37 = "${test_base}/model/GRCh38-to-GRCh37/RF-train_GRCh38-to-GRCh37"
 
     stablelift_models = [
         GRCh37ToGRCh38: [
-            HaplotypeCaller: "${model_37_38}_gSNP_HaplotypeCaller.Rds",
-            Muse2:           "${model_37_38}_sSNV_Muse2.Rds",
-            Mutect2:         "${model_37_38}_sSNV_Mutect2.Rds",
-            SomaticSniper:   "${model_37_38}_sSNV_SomaticSniper.Rds",
-            Strelka2:        "${model_37_38}_sSNV_Strelka2.Rds",
-            "Delly2-gSV":    "${model_37_38}_gSV_Delly2-gSV.Rds",
-            "Delly2-sSV":    "${model_37_38}_sSV_Delly2-sSV.Rds"
+            HaplotypeCaller: "${model_37_38}_HaplotypeCaller.Rds",
+            Muse2:           "${model_37_38}_Muse2.Rds",
+            Mutect2:         "${model_37_38}_Mutect2.Rds",
+            SomaticSniper:   "${model_37_38}_SomaticSniper.Rds",
+            Strelka2:        "${model_37_38}_Strelka2.Rds",
+            "Delly2-gSV":    "${model_37_38}_Delly2-gSV.Rds",
+            "Delly2-sSV":    "${model_37_38}_Delly2-sSV.Rds"
         ],
         GRCh38ToGRCh37: [
-            HaplotypeCaller: "${model_38_37}_gSNP_HaplotypeCaller.Rds",
-            Muse2:           "${model_38_37}_sSNV_Muse2.Rds",
-            Mutect2:         "${model_38_37}_sSNV_Mutect2.Rds",
-            SomaticSniper:   "${model_38_37}_sSNV_SomaticSniper.Rds",
-            Strelka2:        "${model_38_37}_sSNV_Strelka2.Rds",
-            "Delly2-gSV":    "${model_38_37}_gSV_Delly2-gSV.Rds",
-            "Delly2-sSV":    "${model_38_37}_sSV_Delly2-sSV.Rds"
+            HaplotypeCaller: "${model_38_37}_HaplotypeCaller.Rds",
+            Muse2:           "${model_38_37}_Muse2.Rds",
+            Mutect2:         "${model_38_37}_Mutect2.Rds",
+            SomaticSniper:   "${model_38_37}_SomaticSniper.Rds",
+            Strelka2:        "${model_38_37}_Strelka2.Rds",
+            "Delly2-gSV":    "${model_38_37}_Delly2-gSV.Rds",
+            "Delly2-sSV":    "${model_38_37}_Delly2-sSV.Rds"
         ]
     ]
 

--- a/module/call_gSNP/workflow.nf
+++ b/module/call_gSNP/workflow.nf
@@ -21,6 +21,9 @@ workflow call_gSNP {
                 .map{ it ->
                     def tools_to_move = ['HaplotypeCaller'];
                     params.sample_data.each { s, s_data ->
+                        if (!(s_data["original_data"] instanceof Map)) {
+                            return;
+                        }
                         s_data["original_data"].getOrDefault("VCF", []).each { vcf_data ->
                             if (tools_to_move.contains(vcf_data['tool'])) {
                                 s_data[params.this_pipeline][vcf_data['tool']] = vcf_data['vcf_path'];

--- a/module/call_gSV/workflow.nf
+++ b/module/call_gSV/workflow.nf
@@ -22,6 +22,9 @@ workflow call_gSV {
                 .map{ it ->
                     def tools_to_move = ['Manta-gSV', 'Delly2-gSV'];
                     params.sample_data.each { s, s_data ->
+                        if (!(s_data["original_data"] instanceof Map)) {
+                            return;
+                        }
                         s_data["original_data"].getOrDefault("VCF", []).each { vcf_data ->
                             if (tools_to_move.contains(vcf_data['tool'])) {
                                 s_data[params.this_pipeline][vcf_data['tool']] = vcf_data['vcf_path'];

--- a/module/call_sSNV/workflow.nf
+++ b/module/call_sSNV/workflow.nf
@@ -30,6 +30,9 @@ workflow call_sSNV {
                     } else {
                         def tools_to_move = ['Mutect2', 'MuSE', 'SomaticSniper', 'Strelka2', 'BCFtools-Intersect'];
                         params.sample_data.each { s, s_data ->
+                            if (!(s_data["original_data"] instanceof Map)) {
+                                return;
+                            }
                             s_data["original_data"].getOrDefault("VCF", []).each { vcf_data ->
                                 if (tools_to_move.contains(vcf_data['tool'])) {
                                     s_data[params.this_pipeline][vcf_data['tool']] = vcf_data['vcf_path'];

--- a/module/call_sSV/workflow.nf
+++ b/module/call_sSV/workflow.nf
@@ -108,6 +108,9 @@ workflow call_sSV {
                 .map{ it ->
                     def tools_to_move = ['Manta-sSV', 'Delly2-sSV'];
                     params.sample_data.each { s, s_data ->
+                        if (!(s_data["original_data"] instanceof Map)) {
+                            return;
+                        }
                         s_data["original_data"].getOrDefault("VCF", []).each { vcf_data ->
                             if (tools_to_move.contains(vcf_data['tool'])) {
                                 s_data[params.this_pipeline][vcf_data['tool']] = vcf_data['vcf_path'];


### PR DESCRIPTION
- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Fixing a bug for checking for VCF input. FASTQ input is given as an ArrayList and the check treated the original input as a Map, causing an error when FASTQ input is given

## Testing Results
Tested with VCF input: `/hot/software/pipeline/metapipeline-DNA/Nextflow/development/7.0.0-rc.2/yashpatel-fix-vcf-handling/vcf_input_test/run.log`
Tested with FASTQ input: `/hot/software/pipeline/metapipeline-DNA/Nextflow/development/7.0.0-rc.2/yashpatel-fix-vcf-handling/log-nftest-20250404T165008Z.log`