### PR TITLE
Validation cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Validation of StableLift models to only validate when StableLift is selected to run
+
 ### Added
 
 - Calculate-mtDNA-CopyNumber pipeline

--- a/config/methods.config
+++ b/config/methods.config
@@ -361,8 +361,9 @@ methods {
         schema.load_custom_types("${projectDir}/config/custom_schema_types.config", true);
         def metapipeline_schema = schema.load_schema("${projectDir}/config/schema.yaml");
         def pipeline_params_schema = ['pipeline_params': metapipeline_schema.pipeline_params];
-        pipeline_params_schema.elements.each { key, value ->
-            value.required = (params.pipeline_params.containsKey(key) && params.pipeline_params[key].is_pipeline_enabled);
+
+        pipeline_params_schema.pipeline_params.elements.removeAll{ key, value ->
+            !(params.pipeline_params.containsKey(key) && params.pipeline_params[key].is_pipeline_enabled)
         }
 
         schema.validate_specific(pipeline_params_schema, params, []);
@@ -429,10 +430,25 @@ methods {
         }
     }
 
+    validate_stablelift_models = {
+        Map params_to_validate = [:]
+
+        if (params.containsKey('stablelift_models')) {
+            params_to_validate['stablelift_models'] = params.stablelift_models
+        }
+
+        schema.load_custom_types("${projectDir}/config/custom_schema_types.config", true);
+        def metapipeline_schema = schema.load_schema("${projectDir}/config/schema.yaml");
+
+        def stablelift_models_schema = ['stablelift_models': metapipeline_schema['stablelift_models']];
+
+        schema.validate_specific(stablelift_models_schema, params_to_validate, []);
+    }
+
     set_up = {
         input_handler.convert_csv_inputs()
         schema.load_custom_types("${projectDir}/config/custom_schema_types.config")
-        schema.validate_specific("${projectDir}/config/schema.yaml", params, ['pipeline_params'])
+        schema.validate_specific("${projectDir}/config/schema.yaml", params, ['pipeline_params', 'stablelift_models'])
         input_handler.handle_inputs()
         methods.set_output_dirs()
         methods.set_pipeline_logs()
@@ -441,6 +457,7 @@ methods {
         methods.set_env()
         pipeline_selector.handle_pipeline_selection()
         if (params.pipeline_params["StableLift"].is_pipeline_enabled) {
+            methods.validate_stablelift_models()
             methods.expand_stablelift_params()
         }
         methods.generate_pipeline_interval_params()


### PR DESCRIPTION
- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the pipeline on at least one A-mini sample.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Updating parameter validation to consider whether StableLift is selected to run. The update ensures that the `stablelift_models` parameter only gets validated when `StableLift` is enabled

Tested with config-only:
- Valid config with no StableLift, with bad stablelift_models parameter, expected to have no errors as the parameter isn't needed and shouldn't be validated:
```Bash
N E X T F L O W  ~  version 23.04.2
INFO - With the override options, [] will be skipped.
INFO - Attempting to validate pipeline-align-DNA parameters...
INFO - Validated pipeline-align-DNA params
INFO - Attempting to validate pipeline-recalibrate-BAM parameters...
INFO - Validated pipeline-recalibrate-BAM params
INFO - Attempting to validate pipeline-call-gSNP parameters...
INFO - Validated pipeline-call-gSNP params
INFO - Attempting to validate pipeline-call-sSNV parameters...
INFO - Validated pipeline-call-sSNV params
INFO - Attempting to validate pipeline-call-sSV parameters...
INFO - Validated pipeline-call-sSV params
INFO - Attempting to validate pipeline-call-sCNA parameters...
INFO - Validated pipeline-call-sCNA params
INFO - Attempting to validate pipeline-generate-SQC-BAM parameters...
INFO - Validated pipeline-generate-SQC-BAM params
INFO - Attempting to validate pipeline-calculate-targeted-coverage parameters...
INFO - Validated pipeline-calculate-targeted-coverage params
INFO - Attempting to validate pipeline-call-SRC parameters...
INFO - Validated pipeline-call-SRC params
INFO - Attempting to validate pipeline-StableLift parameters...
INFO - pipeline-StableLift is not enabled, skipping validation...
INFO - Attempting to validate pipeline-annotate-VCF parameters...
INFO - Validated pipeline-annotate-VCF params
INFO - Attempting to validate pipeline-call-GeneticAncestry parameters...
INFO - Validated pipeline-call-GeneticAncestry params
INFO - Attempting to validate pipeline-calculate-mtDNA-CopyNumber parameters...
INFO - Validated pipeline-calculate-mtDNA-CopyNumber params
DONE
```
- Valid config with StableLift, with bad stablelift_models parameter, expected to have errors as the parameter is needed and should be validated:
```Bash
N E X T F L O W  ~  version 23.04.2
INFO - With the override options, [] will be skipped.
ERROR ~ Unable to parse config file: '/scratch/metapipelinetest/test.config'

  /this/is/a/bad/base/model/GRCh37-to-GRCh38/RF-model_GRCh37-to-GRCh38_gSNP_HaplotypeCaller.Rds does not exist.


 -- Check '.nextflow.log' file for details
```
- Valid config with StableLift, with good stablelift_models parameter, expected to have no errors as the parameter is needed and should be validated:
```Bash
N E X T F L O W  ~  version 23.04.2
INFO - With the override options, [] will be skipped.
INFO - Attempting to validate pipeline-align-DNA parameters...
INFO - Validated pipeline-align-DNA params
INFO - Attempting to validate pipeline-recalibrate-BAM parameters...
INFO - Validated pipeline-recalibrate-BAM params
INFO - Attempting to validate pipeline-call-gSNP parameters...
INFO - Validated pipeline-call-gSNP params
INFO - Attempting to validate pipeline-call-sSNV parameters...
INFO - Validated pipeline-call-sSNV params
INFO - Attempting to validate pipeline-call-sSV parameters...
INFO - Validated pipeline-call-sSV params
INFO - Attempting to validate pipeline-call-sCNA parameters...
INFO - Validated pipeline-call-sCNA params
INFO - Attempting to validate pipeline-generate-SQC-BAM parameters...
INFO - Validated pipeline-generate-SQC-BAM params
INFO - Attempting to validate pipeline-calculate-targeted-coverage parameters...
INFO - Validated pipeline-calculate-targeted-coverage params
INFO - Attempting to validate pipeline-call-SRC parameters...
INFO - Validated pipeline-call-SRC params
INFO - Attempting to validate pipeline-StableLift parameters...
INFO - Validated pipeline-StableLift params
INFO - Attempting to validate pipeline-annotate-VCF parameters...
INFO - Validated pipeline-annotate-VCF params
INFO - Attempting to validate pipeline-call-GeneticAncestry parameters...
INFO - Validated pipeline-call-GeneticAncestry params
INFO - Attempting to validate pipeline-calculate-mtDNA-CopyNumber parameters...
INFO - Validated pipeline-calculate-mtDNA-CopyNumber params
DONE
```